### PR TITLE
networking.k8s.io/v1

### DIFF
--- a/charts/s3-proxy/templates/ingress.yaml
+++ b/charts/s3-proxy/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $fullName }}

--- a/charts/s3-proxy/templates/ingress.yaml
+++ b/charts/s3-proxy/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "s3-proxy.fullname" . -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -35,9 +35,13 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+                  number: 80
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Use networking.k8s.io/v1 Ingress
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122